### PR TITLE
Improve Form::error method

### DIFF
--- a/src/Form.php
+++ b/src/Form.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Jevets\Kirby;
 
@@ -224,18 +224,19 @@ class Form implements FormInterface
      *
      * If no key is provided, the first error will be returned.
      *
-     * @param  string  optional  $key
+     * @param  string  $key  optional
+     *
+     * @return  array
      */
     public function error($key = '')
     {
         $errors = $this->errors();
 
-        if ($key && isset($errors[$key]))
-            return $errors[$key];
+        if ($key) {
+            return isset($errors[$key]) ? $errors[$key] : [];
+        }
 
-        if (count($errors))
-            return $errors[0];
-
-        return [];
+        // Return first array element or an empty array if there is no first element.
+        return reset($errors) ?: [];
     }
 }


### PR DESCRIPTION
Previously the method failed if there were errors but no error for
the given key (because index `0` did not exist). Now an empty array
is returned if there is no error for the given key.

If no key is provided the method will now return the first error
no matter what the keys of the errors are or an empty array if
there are no errors at all.

With this PR the following feedback mechanism will be possible:

```html+php
<input<?php if ($form->error('name')): ?> class="error"<?php endif; ?> name="name">
```