### PR TITLE
Improve Form::addErrors method

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ This example assumes you're using [page controllers in Kirby](http://getkirby.co
 
 <?php if (count($form->errors()) > 0): ?>
     <div class="alert alert-error">
-        <?php foreach ($form->errors() as $key => $error): ?>
-            <div><?= $error ?></div>
+        <?php foreach ($form->errors() as $key => $errors): ?>
+            <div><?= implode('<br>', $errors) ?></div>
         <?php endforeach ?>
     </div>
 <?php endif ?>

--- a/src/Form.php
+++ b/src/Form.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 namespace Jevets\Kirby;
 
@@ -195,7 +195,12 @@ class Form implements FormInterface
     /**
      * Add errors
      *
-     * @param  array  $data
+     * Each error will be an array of error messages.
+     *
+     * @param  array  $data  Each item can be either a single error message that will be
+     *                       appended to the errors array of the key or it can be an
+     *                       array of error messages that will be merged with the errors
+     *                       array of the key.
      * @return void
      */
     public function addErrors($data)
@@ -203,7 +208,15 @@ class Form implements FormInterface
         $errors = $this->errors();
 
         foreach ($data as $key => $value) {
-            $errors[$key] = $value;
+            if (!isset($errors[$key])) {
+                $errors[$key] = [];
+            }
+
+            if (is_array($value)) {
+                $errors[$key] = array_merge($errors[$key], $value);
+            } else {
+                $errors[$key][] = $value;
+            }
         }
 
         $this->flash->set(self::FLASH_KEY_ERRORS, $errors);


### PR DESCRIPTION
Each key will have an array of error messages now instead of just one error message. This is consistent with the behavior of Laravel and will support the improved validation of getkirby/toolkit#205.